### PR TITLE
Bearn.Fi report incorrectly duplicated on xToken hack

### DIFF
--- a/defi/2021.md
+++ b/defi/2021.md
@@ -315,7 +315,6 @@ Incidents involving DeFi, DEX, NFT, and other smart contract projects. Subscribe
   References:
     * [Initial Report on xBNTa, xSNXa Exploit](https://medium.com/xtoken/initial-report-on-xbnta-xsnxa-exploit-d6e784387f8e) by Michael J. Cohen (xToken)
     * [Exploit Analysis](https://twitter.com/frankresearcher/status/1392515198674681863) by Igor Igamberdiev (@FrankResearcher)
-    * [Bearn.Fi Incident: Inconsistent Asset Denomination Between Vault & Strategy](https://peckshield.medium.com/bearn-fi-incident-inconsistent-asset-denomination-between-vault-strategy-9b24b68ab1c0) by PeckShield
     * [xToken - REKT](https://www.rekt.news/xtoken-rekt/) by rekt
 
 


### PR DESCRIPTION
The Bearn.Fi report was linked to twice. This removes the duplicated link which was incorrectly on the xToken hack.

The correct link, under the bearn.Fi report remains.